### PR TITLE
增加微信公众平台测试号推送功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@ docker run -v /etc/localtime:/etc/localtime:ro \
 ![image](http://cdn.hanyajun.com/20190530_233034_wechat8.png)
 
 **微信通知有个缺点，就是网页版微信只能有一个终端登录**
+
+##### 通过微信公众平台(测试号)推送
+
+访问 https://mp.weixin.qq.com/debug/cgi-bin/sandbox?t=sandbox/login
+微信扫一扫开通并关注测试号，填写 appid 和 appsecret 运行即可在订阅号中找到该测试号推送的消息
+
+```bash
+docker run -d -v /etc/localtime:/etc/localtime:ro \
+    -e NOTICE_TYPE=disable \
+    -e WECHAT_PUSH=push \
+    -e WECHAT_APP_ID=wxf123456789 \
+    -e WECHAT_APP_SECRET=adcdefg123456789 \
+    hanyajun/news_watch_notice
+```
+
 ##### 通过邮箱推送
 
 ```

--- a/cmd/news_watch_notice.go
+++ b/cmd/news_watch_notice.go
@@ -28,6 +28,9 @@ func main() {
 	var sendObject mail.SendObject
 	var githubPushFlag bool
 	var githubToken string
+	var wechatPushFlag bool
+	var wechatAppId string
+	var wechatAppSecret string
 
 	// notice
 	if noticeType == utils.TYPENOCICEMAIL {
@@ -69,6 +72,12 @@ func main() {
 		githubPushFlag = true
 		githubToken = utils.GetValueFromEnv("GITHUB_TOKEN")
 	}
+	if utils.GetValueFromEnv("WECHAT_PUSH") == utils.WECHATPUSHFLAG {
+		wechatPushFlag = true
+		wechatAppId = utils.GetValueFromEnv("WECHAT_APP_ID")
+		wechatAppSecret = utils.GetValueFromEnv("WECHAT_APP_SECRET")
+	}
+
 	t := time.Tick(time.Minute * 30)
 
 	var gocnDateTime string
@@ -190,6 +199,27 @@ func main() {
 					}
 
 				}
+
+				if wechatPushFlag {
+					msg := "第" + time.Now().Format("2006-01-02") + "期" + "\n\n"
+					if content != "" {
+						msg += "GOCN每日新闻" + "\n\n" + content + "\n\n\n"
+					}
+
+					if studyContent != "" {
+						msg += "GO语言中文网每日资讯" + "\n\n" + studyContent + "\n\n\n"
+					}
+
+					if gopherDailyContent != "" {
+						msg += "Gopher Daily" + "\n\n" + gopherDailyContent
+					}
+
+					err = wechat.WeChatPush(wechatAppId, wechatAppSecret, msg)
+					if err != nil {
+						fmt.Println("wechat push:", err)
+					}
+				}
+
 				if !typeFlag {
 					err = wechat.WechatSendMsgs(content, userList, loginMap)
 				} else if slackFlag {

--- a/cmd/news_watch_notice.go
+++ b/cmd/news_watch_notice.go
@@ -28,6 +28,8 @@ func main() {
 	var sendObject mail.SendObject
 	var githubPushFlag bool
 	var githubToken string
+
+	// notice
 	if noticeType == utils.TYPENOCICEMAIL {
 		typeFlag = true
 		host := utils.GetValueFromEnv("NOTICE_MAIL_HOST")
@@ -48,6 +50,8 @@ func main() {
 		typeFlag = true
 		slackFlag = true
 		webHookUrl = utils.GetValueFromEnv("NOTICE_SLACK_WEB_HOOK_URL")
+	} else if noticeType == utils.TYPENOCDISABLE {
+		// nothing
 	} else {
 		/* 登陆微信 */
 		err, loginMap = wechat.WechatLogin()
@@ -59,6 +63,8 @@ func main() {
 		}
 		userList = wechat.GetSendUsers(loginMap, u)
 	}
+
+	// push
 	if utils.GetValueFromEnv("GITHUB_PUSH") == utils.GITHUBPUSHFLAG {
 		githubPushFlag = true
 		githubToken = utils.GetValueFromEnv("GITHUB_TOKEN")

--- a/pkg/wechat/push.go
+++ b/pkg/wechat/push.go
@@ -1,0 +1,104 @@
+package wechat
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+type Token struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+type Msg struct {
+	Filter struct {
+		IsToAll bool   `json:"is_to_all"`
+		TagId   string `json:"tag_id"`
+	} `json:"filter"`
+	Text struct {
+		Content string `json:"content"`
+	} `json:"text"`
+	MsgType string `json:"msgtype"`
+}
+
+type Result struct {
+	ErrCode int    `json:"errcode"`
+	ErrMsg  string `json:"errmsg"`
+	MsgId   int32  `json:"msg_id"`
+}
+
+// https://developers.weixin.qq.com/doc/offiaccount/Basic_Information/Get_access_token.html
+func WeChatAccessToken(appId, appSecret string) (string, error) {
+	url := "https://api.weixin.qq.com/cgi-bin/token?grant_type=client_credential&appid=" + appId + "&secret=" + appSecret
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	} else if resp.StatusCode != http.StatusOK {
+		return "", errors.New("status code is not 200")
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if bytes.Contains(body, []byte("access_token")) {
+		token := Token{}
+		err = json.Unmarshal(body, &token)
+		if err != nil {
+			return "", err
+		}
+
+		return token.AccessToken, nil
+	}
+
+	return "", errors.New("get access token failed")
+}
+
+// https://developers.weixin.qq.com/doc/offiaccount/Message_Management/Batch_Sends_and_Originality_Checks.html
+func WeChatPush(appId, appSecret, text string) error {
+	accessToken, err := WeChatAccessToken(appId, appSecret)
+	if err != nil {
+		return err
+	}
+
+	msg := Msg{}
+	msg.Filter.IsToAll = true
+	msg.Text.Content = text
+	msg.MsgType = "text"
+	data, err := json.Marshal(&msg)
+	if err != nil {
+		return err
+	}
+
+	url := "https://api.weixin.qq.com/cgi-bin/message/mass/sendall?access_token=" + accessToken
+	resp, err := http.Post(url, "application/json;charset=UTF-8", strings.NewReader(string(data)))
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if bytes.Contains(body, []byte("errcode")) {
+		result := Result{}
+		err = json.Unmarshal(body, &result)
+		if err != nil {
+			return err
+		}
+
+		if result.ErrCode != 0 {
+			err = errors.New(result.ErrMsg)
+		}
+	}
+
+	return err
+}

--- a/utils/common_utils.go
+++ b/utils/common_utils.go
@@ -15,6 +15,7 @@ import (
 const (
 	TYPENOCICEMAIL = "mail"
 	TYPENOCTISLACK = "slack"
+	TYPENOCDISABLE = "disable"
 	GITHUBPUSHFLAG = "push"
 )
 

--- a/utils/common_utils.go
+++ b/utils/common_utils.go
@@ -17,6 +17,7 @@ const (
 	TYPENOCTISLACK = "slack"
 	TYPENOCDISABLE = "disable"
 	GITHUBPUSHFLAG = "push"
+	WECHATPUSHFLAG = "push"
 )
 
 //去掉""


### PR DESCRIPTION
1.增加屏蔽 `notice` 仅用 `push` 开关
2.增加使用 微信公众平台 **测试号** 群发消息推送